### PR TITLE
feat: implementation for v0.10.1

### DIFF
--- a/3gpp/pom.xml
+++ b/3gpp/pom.xml
@@ -5,12 +5,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>3gpp</artifactId>
-  <version>v0.10.0-rc</version>
+  <version>v0.10.1</version>
 
   <parent>
     <groupId>com.camara</groupId>
     <artifactId>qod</artifactId>
-    <version>v0.10.0-rc</version>
+    <version>v0.10.1</version>
   </parent>
 
   <dependencies>
@@ -46,10 +46,6 @@
       <version>${migbase64-version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
@@ -57,7 +53,7 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.0.2</version>
+      <version>${jakarta-version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -91,7 +87,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>${servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -125,6 +121,8 @@
               <openapiNormalizer>
                 SIMPLIFY_ANYOF_STRING_AND_ENUM_STRING=true
               </openapiNormalizer>
+              <generateApiTests>false</generateApiTests>
+              <generateModelTests>false</generateModelTests>
             </configuration>
           </execution>
           <execution>
@@ -143,9 +141,9 @@
                 <delegatePattern>true</delegatePattern>
                 <useJakartaEe>true</useJakartaEe>
               </configOptions>
-              <environmentVariables>
+              <globalProperties>
                 <apis>notifications</apis>
-              </environmentVariables>
+              </globalProperties>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
             </configuration>
@@ -155,7 +153,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>${maven-plugin.version}</version>
         <configuration>
           <skipTests>true</skipTests>
           <testFailureIgnore>true</testFailureIgnore>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,278 +2,54 @@
 
 ## Table of Contents
 
-- [v0.10.0-rc](#v0100-rc)
+- **[v0.10.1](#v0101)**
+- [v0.10.0](#v0100)
 - [v0.9.0](#v090)
-- [v0.9.0-rc](#v090-rc)
 - [v0.8.1](#v081)
 - [v0.8.0](#v080)
-- [v0.1.0 - Initial contribution](#v010---initial-contribution)
 
-Version numbers 0.2.x to 0.7.x were intentionally not used to avoid conflicts with local implementations.
-
-**Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code
-in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best
-results, use the latest published release.**
-
-# v0.10.0-rc
-
-**This is the release candidate of v0.10.0 - containing the upcoming fourth alpha version of the Quality-On-Demand (QoD) API**
-
-- API definition **with inline documentation**:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.10.0-rc/code/API_definitions/qod-api.yaml)
-
-## Please note:
-
-- **This release will contain significant changes compared to v0.9.0, and it is not backward compatible**
-    - Within notifications the schema `EventNotification`has been replace by `CloudEvent` in accordance with the updated CAMARA Design
-      Guidelines
-    - If within `device` an IPv6 address is used it must be a single IPv6 address (out of the prefix used by the device)
-- **This is only the pre-release, it should be considered as a draft of the upcoming release v0.10.0**
-    - The pre-release is meant for implementors, but it is not recommended to use the API with customers in productive environments.
-
-### Main Changes
-
-* Aligned event notification with CloudEvent spec which will allow API consumers and implementators to use standard libraries and tools
-  which are available to handle CloudEvents (https://cloudevents.io/)
-* Added a new operation `/sessions/{sessionId}/extend` which allows to extend the duration of an active session
-
-### Added
-
-* Added new endpoint to extend duration of an active session by @emil-cheung in https://github.com/camaraproject/QualityOnDemand/pull/216
-* Introduced of linting with Megalinter and Swagger Editor Validator by @RandyLevensalor, @maxl2287 and @ravindrapalaskar17
-  in https://github.com/camaraproject/QualityOnDemand/pull/206, https://github.com/camaraproject/QualityOnDemand/pull/207, https://github.com/camaraproject/QualityOnDemand/pull/212,
-  and  https://github.com/camaraproject/QualityOnDemand/pull/215
-* Added global tags element by @rartych in https://github.com/camaraproject/QualityOnDemand/pull/227
-
-### Changed
-
-* Align event notification with CloudEvents spec by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/224
-* Moved "description" out of "allOf" declaration by @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/205
-    * Note: this change shouldn't have an impact for API consumers but is relevant for implementations of the API.
-* Aligned with changes in https://github.com/camaraproject/Template_Lead_Repository on test definitions by @rartych
-  in https://github.com/camaraproject/QualityOnDemand/pull/233
-* Single IP addresses in Device model specified with standard formats instead of patterns by @jlurien
-  in https://github.com/camaraproject/QualityOnDemand/pull/237
-
-### Fixed
-
-* NA
-
-### Removed
-
-* NA
-
-## New Contributors
-
-* @ravindrapalaskar17 made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/215
-* @rartych made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/227
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.9.0...v0.10.0-rc
-
-# v0.9.0
-
-**This is the third alpha version of the Quality-On-Demand (QoD) API.**
-
-- API definition **with inline documentation**:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/QualityOnDemand/blob/release-0.9.0/code/API_definitions/qod-api.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/QualityOnDemand/release-0.9.0/code/API_definitions/qod-api.yaml)
-
-## Please note:
-
-- **This release contains significant breaking changes compared to v0.8.1, and it is not backward compatible**
-    - Especially a lot of the parameter names changed in line with the agreed glossary within CAMARA Commonalities
-- This is an alpha version, it should be considered as a draft.
-- There are bug fixes to be expected and incompatible changes in upcoming versions.
-- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-
-### Added
-
-* Introduced `qosStatus` and corresponding notification event to fix issue #38 by @emil-cheung
-  in https://github.com/camaraproject/QualityOnDemand/pull/67
-* Added basic tests with Cucumber framework using Java and Maven implementation by @mdomale
-  in https://github.com/camaraproject/QualityOnDemand/pull/134
-* Added new methods to get service provider defined QoS Profile by @RandyLevensalor
-  in https://github.com/camaraproject/QualityOnDemand/pull/138
-* Scopes specified and OAuth2 authorizationCode flow added as security mechanism, for operations dealing with QoD sessions by @jlurien
-  in https://github.com/camaraproject/QualityOnDemand/pull/163
-* Added new model `EventQosStatus` by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/167
-
-### Changed
-
-* Aligned error format with CAMARA design guidelines by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/104
-* Renamed properties to new terms agreed in CAMARA Commonalitites by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/129
-* Updated method for identifying devices by IPv4 address by @eric-murray in https://github.com/camaraproject/QualityOnDemand/pull/139
-* Updated of the notification event related fields based on the CAMARA design guideline by @akoshunyadi
-  in https://github.com/camaraproject/QualityOnDemand/pull/155
-* CAMARA documentation is now embedded within the OAS definition, and not separate by @jlurien
-  in https://github.com/camaraproject/QualityOnDemand/pull/151
-
-### Fixed
-
-* Added error code 501 "Not Implemented" by @dfischer-tech in https://github.com/camaraproject/QualityOnDemand/pull/124
-* Added inheritance between Event and QosStatusChangedEvent and simplified notification payload model by @patrice-conil
-  in https://github.com/camaraproject/QualityOnDemand/pull/177
-
-### Removed
-
-* Removed format lines from Datatypes `Ipv4Address` and `Ipv6Address` by @tlohmar
-  in https://github.com/camaraproject/QualityOnDemand/pull/177
-* Removed markdown documentation (now embedded within the OAS definition, see above)
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.8.1...v0.9.0
-
-# v0.9.0-rc
-
-**This is the release candidate of v0.9.0 - the (third alpha (tbc)) release of the Quality-On-Demand (QoD) API**
-
-- [API definition with inline documentation](https://github.com/camaraproject/QualityOnDemand/blob/v0.9.0-rc/code/API_definitions/qod-api.yaml)
-
-## Please note:
-
-- **This release contains significant changes compared to v0.8.1, and it is not backward compatible**
-    - Especially a lot of the parameter names changed in line with the agreed glossary within CAMARA Commonalities
-- **This is only the pre-release, it should be considered as a draft of the upcoming release v0.9.0**
-- The pre-release is meant for implementors, but it is not recommended to use the API with customers in productive environments.
-
-### Added
-
-* Introduced `qosStatus` and corresponding notification event to fix issue #38 by @emil-cheung
-  in https://github.com/camaraproject/QualityOnDemand/pull/67
-* Added basic tests with Cucumber framework using Java and Maven implementation by @mdomale
-  in https://github.com/camaraproject/QualityOnDemand/pull/134
-* Added new methods to get service provider defined QoS Profile by @RandyLevensalor
-  in https://github.com/camaraproject/QualityOnDemand/pull/138
-* Scopes specified and OAuth2 authorizationCode flow added as security mechanism, for operations dealing with QoD sessions by @jlurien
-  in https://github.com/camaraproject/QualityOnDemand/pull/163
-* Added new model `EventQosStatus` by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/167
-
-### Changed
-
-* Aligned error format with CAMARA design guidelines by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/104
-* Renamed properties to new terms agreed in CAMARA Commonalitites by @jlurien in https://github.com/camaraproject/QualityOnDemand/pull/129
-* Updated method for identifying devices by IPv4 address by @eric-murray in https://github.com/camaraproject/QualityOnDemand/pull/139
-* Updated of the notification event related fields based on the CAMARA design guideline by @akoshunyadi
-  in https://github.com/camaraproject/QualityOnDemand/pull/155
-* CAMARA documentation is now embedded within the OAS definition, and not separate by @jlurien
-  in https://github.com/camaraproject/QualityOnDemand/pull/151
-
-### Fixed
-
-* Added error code 501 "Not Implemented" by @dfischer-tech in https://github.com/camaraproject/QualityOnDemand/pull/124
-
-### Removed
-
-* Removed format lines from Datatypes `Ipv4Address` and `Ipv6Address` by @tlohmar
-  in https://github.com/camaraproject/QualityOnDemand/pull/153
-* Removed markdown documentation (now embedded within the OAS definition, see above)
-
-## New Contributors
-
-* @jlurien made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/104
-* @dfischer-tech made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/124
-* @maheshc01 made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/132
-* @eric-murray made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/139
-* @mdomale made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/134
-* @RandyLevensalor made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/138
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.8.1...v0.9.0-rc
-
-# v0.8.1
-
-**This is the second alpha release of the Quality-On-Demand (QoD) API**
-
-- API [definition](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.1/code/API_definitions)
-- API [documentation](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.1/documentation/API_documentation)
-
-## Please note:
-
-- **This minor release contains minor fixes of v0.8.0, but is not backward compatible to v0.8.0**
-- This is an alpha version, it should be considered as a draft.
-- There are bug fixes to be expected and incompatible changes in upcoming versions.
-- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-
-### Added
-
-* Added Generic error 500 to remaining procedures by @SfnUser in https://github.com/camaraproject/QualityOnDemand/pull/86
-
-### Changed
-
-* Update from notificationsUri to notificationsUrl by @maxl2287 in https://github.com/camaraproject/QualityOnDemand/pull/89
-* Update and rename QoD_Latency_Bandwidth_User_Story.md by @hdamker in https://github.com/camaraproject/QualityOnDemand/pull/103
-
-### Fixed
-
-* Fixed two typos in qod-api.yaml by @SfnUser in https://github.com/camaraproject/QualityOnDemand/pull/77
-
-### Removed
-
-## New Contributors
-
-* @maxl2287 made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/89
-* @SfnUser made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/77
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.8.0...v0.8.1
-
-# v0.8.0
-
-**This is the first alpha version of the Quality-On-Demand (QoD) API.**
-
-- API [definition](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.0/code/API_definitions)
-- API [documentation](https://github.com/camaraproject/QualityOnDemand/tree/release-0.8.0/documentation/API_documentation)
-
-## Please note:
-
-- This is an alpha version, it should be considered as a draft.
-- There are bug fixes to be expected and incompatible changes in upcoming versions.
-- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-- Version numbers 0.2.x to 0.7.x were used in private versions during the development of the API and are here not used to avoid conflicts
-  with local implementations.
-- Provider implementations (PI) will be provided within separate repositories:
-    - [QualityOnDemand_PI1](https://github.com/camaraproject/QualityOnDemand_PI1) by Deutsche Telekom
-    - [QualityOnDemand_PI2](https://github.com/camaraproject/QualityOnDemand_PI2) by Orange
-
-## What's Changed
-
-* Contribution of the QoD-API spec v0.8.0 by @akoshunyadi in https://github.com/camaraproject/QualityOnDemand/pull/54
-* Improvements for QoSProfile_Mapping_Table.md by @tlohmar in https://github.com/camaraproject/QualityOnDemand/pull/62 and @hdamker
-  in https://github.com/camaraproject/QualityOnDemand/pull/73
-* Update qod api documentation to 0.8.0 by @shilpa-padgaonkar in https://github.com/camaraproject/QualityOnDemand/pull/71
-* Editorial updates of documentation QoD_API.md by @hdamker, @kaikreuzer, and @mariobodemann
-* Delete code/API_code directory by @hdamker in https://github.com/camaraproject/QualityOnDemand/pull/93
-
-## New Contributors
-
-* @akoshunyadi made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/54
-* @tlohmar made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/62
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/compare/v0.1.0...v0.8.0
-
-# v0.1.0 - Initial contribution
-
-**Initial contribution of two API definitions for Quality on Demand (stable bandwidth and stable latency)**, including initial documentation
-and implementation code.
-
-## Please note
-
-- this "release" is only tagged to document the history of the API, it is not intended to be used by implementors or API customers
-- it was implemented by Deutsche Telekom within lab environment and tested against two NEF implementations
-- going forward the
-  implementation [code](https://github.com/camaraproject/QualityOnDemand/tree/50e81e0c4a6a7431c0a7f50c26415caf935be6df/code/API_code) will
-  not be part of releases of QoD API. Instead it will be provided within separate repositories (QualityOnDemand_PIx).
-
-## What's Changed
-
-* Qod latency api spec 0.1.0 contribution by @shilpa-padgaonkar in https://github.com/camaraproject/QualityOnDemand/pull/24
-* Qod bandwidth api spec 0.1.0 contribution by @shilpa-padgaonkar in https://github.com/camaraproject/QualityOnDemand/pull/25
-* Code contribution for release 0.1.0 by @anjagerlach in https://github.com/camaraproject/QualityOnDemand/pull/28
-* Create QoD-API-Readiness-Checklist.md by @shilpa-padgaonkar in https://github.com/camaraproject/QualityOnDemand/pull/30
-
-## New Contributors
-
-* @T-sm made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/10
-* @anjagerlach made their first contribution in https://github.com/camaraproject/QualityOnDemand/pull/28
-
-**Full Changelog**: https://github.com/camaraproject/QualityOnDemand/commits/v0.1.0
+### v0.10.1
+
+- adaption for extending a session
+- check creation of session based on requested QoS profile
+- dependency upgrades
+
+### v0.10.0
+
+- Align event notification with CloudEvents spec
+- Added a new operation /sessions/{sessionId}/extend which allows extending the duration of an active session
+- Added "DELETE_REQUESTED" as statusInfo information via CloudEvent, when a session got deleted by the user
+- If the network calls back with SESSION_TERMINATION or FAILED_RESOURCES_ALLOCATION, then after 360s the session will be deleted.
+- Single IP addresses in Device-model specified with standard formats instead of patterns
+- Add IPv4 validation for device.ipv4Address.publicAddress
+- Improve security for REST-Endpoints
+- Notification event structure updated to comply with CloudEvents specification.
+- In the Device model, single IP addresses are now specified with standard formats instead of patterns.
+- Notifications will now be sent for all changes of QosStatus, even if initiated by the client.
+- remove automatic attachment of "/notifications" from notificationUrl for CloudEvents
+
+### v0.9.0
+
+- Introduced qosStatus and corresponding notification event
+- new /qos-profiles - endpoints
+- minor changes in Exception-Handling
+- Updated method for identifying devices by IPv4 address.
+- Updated notification event-related fields to adhere to CAMARA design guidelines.
+- Changed request parameter class from UeId to Device.
+- Renamed request parameter from MSISDN to phoneNumber.
+- Renamed request parameter from externalId to networkAccessIdentifier.
+- Renamed request parameter from ipv4addr to ipv4Address.
+- Renamed request parameter from ipv6Addr to ipv6Address.
+- Renamed request parameter from asId to applicationServer.
+- Renamed request parameter from uePorts to devicePorts.
+- Renamed request parameter from asPorts to applicationServerPorts.
+- Renamed request parameter from qos to qosProfile.
+
+### v0.8.1
+
+- Update from notificationsUri to notificationsUrl.
+- Added Generic error 500 to remaining procedures.
+
+### v0.8.0
+
+- First implementation release of QoD

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To run a QoD API locally, you have to follow these steps:
 
 * Build
 * Create Database
+* Setup Kafka
 * Start QoD API
 
 #### Build
@@ -31,6 +32,14 @@ Therefore, you can use a local instance of Redis DB or start Redis from Docker c
 * local instance on Windows: https://github.com/zkteco-home/redis-windows
 * local instance on Linux: https://redis.io/docs/getting-started/installation/install-redis-on-linux/
 
+#### Setup Kafka
+
+To send and listen CloudEvent-Notifications from QOD-API and Webhook-dispatcher respectively, Kafka server needs to be set up locally. After setup, its host and port information need to be added as follows inside [application.yaml](https://gitlab.devops.telekom.de/hnce/development/avp-dev/avp/-/blob/develop/camara/core/src/main/resources/application.yml?ref_type=heads)
+```
+kafka:
+    producer:
+        bootstrap-servers: localhost:29092
+```
 #### Start QoD API
 
 For information about how to configure the QoD API, please refer to the next section "Configuration".
@@ -55,34 +64,92 @@ The configuration can be adapted here: core/src/main/resources/application.yml
 
 The below table lists the environment variables that are used to configure the application properly. This reference
 implementation for the QoD API makes use of the AsSessionWithQoS API (https://www.3gpp.org/ftp/Specs/latest/Rel-17)
-which is usually made available as a part of a NEF/SCEF system. All variables in the below table starting with "SCEF"
+which is usually made available as a part of a NEF/SCEF system. All variables in the below table starting with "NETWORK"
 can be understood as NEF/SCEF.
 
-| ENV                              | Description                                                                                                               |
-|----------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| SERVER_PORT                      | TCP/IP port listened on by application                                                                                    |
-| MANAGEMENT_SERVER_PORT           | TCP/IP port listened on by application management facilities                                                              |
-| SCEF_SERVER_APIROOT              | SCEF endpoint API root URL                                                                                                |
-| SCEF_SERVER_SCSASID              | ID of SCS or AS providing SCEF endpoint                                                                                   |
-| SCEF_SERVER_SUPPORTEDFEATURES    | A list of supported features used as described in subclause 5.8. (3GPP)                                                   |
-| SCEF_AUTH_OAUTH_TOKEN            | OAuth authentication token for calling SCEF endpoint                                                                      |
-| SCEF_NOTIFICATIONS_URL           | URL for delivering (POST) notifications from SCEF, it should include the path /3gpp-as-session-with-qos/v1/notifications  |
-| QOD_QOS_REFERENCES               | QoS reference for predefined specific QoS parameter set                                                               |
-| SPRING_REDIS_HOST                | Redis server host                                                                                                         |
-| SPRING_REDIS_PORT                | Port where the Redis server is listening                                                                                  |
-| EXPIRATION_TIME-BEFORE-HANDLING  | How many seconds before expiration, should an ExpiredSessionTask be created                                               |
-| EXPIRATION_TRIGGER-INTERVAL      | How often should the ExpiredSessionMonitor check for (almost) expired sessions                                            |
-| EXPIRATION_LOCK-TIME             | How many seconds the session should be locked for the processing of the deletion task                                     |
-| MASK-SENSIBLE-DATA               | If set to true, sensible data is masked in response body                                                                  |
-| ALLOW-MULTIPLE-UEADDR            | If set to true, network segments are allowed for ueAddr                                                                   |
+| ENV                              | Description                                                                                                              |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| SERVER_PORT                      | TCP/IP port listened on by application                                                                                   |
+| MANAGEMENT_SERVER_PORT           | TCP/IP port listened on by application management facilities                                                             |
+| NETWORK_SERVER_APIROOT           | SCEF endpoint API root URL                                                                                               |
+| NETWORK_SERVER_SCSASID           | ID of SCS or AS providing SCEF endpoint                                                                                  |
+| NETWORK_SERVER_SUPPORTEDFEATURES | A list of supported features used as described in subclause 5.8. (3GPP)                                                  |
+| NETWORK_AUTH_OAUTH_TOKEN         | OAuth authentication token for calling SCEF endpoint                                                                     |
+| NETWORK_NOTIFICATIONS_URL        | URL for delivering (POST) notifications from SCEF, it should include the path /3gpp-as-session-with-qos/v1/notifications |
+| QOD_QOS_REFERENCES               | QoS reference for predefined specific QoS parameter set                                                                  |
+| SPRING_REDIS_HOST                | Redis server host                                                                                                        |
+| SPRING_REDIS_PORT                | Port where the Redis server is listening                                                                                 |
+| EXPIRATION_TIME-BEFORE-HANDLING  | How many seconds before expiration, should an ExpiredSessionTask be created                                              |
+| EXPIRATION_TRIGGER-INTERVAL      | How often should the ExpiredSessionMonitor check for (almost) expired sessions                                           |
+| EXPIRATION_LOCK-TIME             | How many seconds the session should be locked for the processing of the deletion task                                    |
+| MASK-SENSIBLE-DATA               | If set to true, sensible data is masked in response body                                                                 |
+| ALLOW-MULTIPLE-UEADDR            | If set to true, network segments are allowed for ueAddr                                                                  |
+
+
+## Implementation Related
+### Introduction
+This document outlines the implementation details for the Quality-on-Demand (QoD) API, which allows developers to request stable latency or throughput for their applications in 4G/5G networks.
+
+### Implemented Version
+v0.10.0
+
+### API Functionality
+
+The QoD API offers functionalities for managing QoS sessions and profiles:
+
+- **Create QoS Sessions:** Developers can create new sessions by specifying the device, application server, desired QoS profile, and optional duration and notification details.
+- **Manage QoS Sessions:**
+    - **Get Session Information:** Retrieve information about an active session using its ID.
+    - **Extend Session Duration:** Extend the duration of an active session.
+    - **Delete Session:** Terminate an active session.
+- **Access QoS Profiles:**
+    - **Get All QoS Profiles:** Retrieve a list of all available QoS profiles, optionally filtered by name or status (ACTIVE, INACTIVE, DEPRECATED).
+    - **Get Specific QoS Profile:** Retrieve details about a specific QoS profile by its name.
+
+```plantuml
+left to right direction
+skinparam componentStyle rectangle
+
+    node "Notification-url" {
+      [Client]
+    }
+    node "NEF Server" {
+      [NEF]
+    }
+    component [User] #LightGrey
+    component [Client] #Pink
+    component [Qod API] #Pink
+    component [Webhook Dispatcher] #Pink
+    component [Kafka] #LightBlue
+    component [NEF] #Yellow
+    [User] --> [Client]: Rest Get Event
+    [User] --> [Qod API]: Create Session
+    [Qod API] ..> [Kafka]: Pub Event
+    [Webhook Dispatcher] ..> [Client]: Rest Callback
+    [Webhook Dispatcher] ..> [Kafka]: Sub Event
+    [NEF] ..> [Qod API]: Rest Callback SESSION_TERMINATION
+    [Qod API] --> [NEF]
+
+```
+
+### Implementation Requirements
+
+- **Swagger Specification:** The API adheres to the provided Swagger specification (https://swagger.io/specification/v2/) to ensure consistency and facilitate client development.
+- **Authentication:** The API utilizes OAuth 2.0 for authentication. Two flows are supported:
+    - **Client Credentials Grant:** Used for server-to-server communication between trusted partners/clients.
+    - **Authorization Code Grant:** Enables user interaction through an authorization server for broader use cases.
+- **Security:** Implement appropriate security measures to protect user data and resources.
+- **Data Model:** Utilize the provided data model definitions in the Swagger specification for request and response structures.
+- **Error Handling:** Implement robust error handling mechanisms to provide informative messages for various error scenarios.
+- **Callback Notifications:** The API supports optional notification callbacks (via CloudEvents) using webhooks to inform developers about session status changes (e.g., DURATION_EXPIRED, NETWORK_TERMINATED, DELETE_REQUESTED).
 
 ## Validations
 
 The QoD reference implementation has been qualified against the following network service vendors:
 
-| System Name        | Vendor       | Camara Testing Member  | Qualified  |
-|--------------------|--------------|------------------------|------------|
-| 5G-NEF             | Ericsson     | DT                     | Yes        |
+| System Name | Vendor   | Camara Testing Member | Qualified |
+|-------------|----------|-----------------------|-----------|
+| 5G-NEF      | Ericsson | DT                    | Yes       |
 
 We actively ask other Camara members to validate this implementation against their available backend network services and
 share the results with the community.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,12 +5,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>senf-api</artifactId>
-  <version>v0.10.0-rc</version>
+  <version>v0.10.1</version>
 
   <parent>
     <groupId>com.camara</groupId>
     <artifactId>qod</artifactId>
-    <version>v0.10.0-rc</version>
+    <version>v0.10.1</version>
   </parent>
 
   <dependencies>

--- a/api/src/main/resources/static/qod-api.yaml
+++ b/api/src/main/resources/static/qod-api.yaml
@@ -38,7 +38,7 @@ info:
     Duration (in seconds) for which the QoS session (between application client and application server) should be created. This parameter is optional. When not specified, a default session duration (e.g. 24 hours) is applied. The user may request a termination before its expiration.
 
     * **Notification URL and token**:
-    Developers may provide a callback URL on which notifications (eg. session termination) regarding the session can be received from the service provider. This is an optional parameter.
+    Developers may provide a callback URL on which notifications about all status change events of the session (eg. session termination) can be received from the service provider. This is an optional parameter.
 
     # API functionality
 
@@ -66,21 +66,18 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.10.0-rc
+  version: 0.10.1
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/
 security:
   - oAuth2ClientCredentials: []
 servers:
-  - url: "{apiRoot}/{basePath}"
+  - url: "{apiRoot}/qod/v0"
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root
-      basePath:
-        default: qod/v0
-        description: Base path for the QoD API
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: QoS Sessions
     description: Manage QoS sessions
@@ -92,7 +89,24 @@ paths:
       tags:
         - QoS Sessions
       summary: Creates a new session
-      description: Create QoS Session to manage latency/throughput priorities
+      description: |
+        Create QoS Session to manage latency/throughput priorities
+
+        If the qosStatus in the API response is "AVAILABLE" and a notification callback is provided the client will receive in addition to the response a
+        `QOS_STATUS_CHANGED` event notification with `qosStatus` as `AVAILABLE`.
+
+        If the `qosStatus` in the API response is `REQUESTED`, the client will receive either
+        - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `AVAILABLE` after the network notifies that it has created the requested session, or
+        - a `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` after the network notifies that it has failed to provide the requested session.
+
+        A `QOS_STATUS_CHANGED` event notification with `qosStatus` as `UNAVAILABLE` will also be send if the network terminates the session before the requested duration expired
+
+        NOTE: in case of a `QOS_STATUS_CHANGED` event with `qosStatus` as `UNAVAILABLE` and `statusInfo` as `NETWORK_TERMINATED` the resources of the QoS session
+        are not directly released, but will get deleted automatically at earliest 360 seconds after the event.
+        This behavior allows clients which are not receiving notification events but are polling to get the session information with
+        the `qosStatus` `UNAVAILABLE` (the `statusInfo` parameter is not included in the current version but will be adding to `SessionInfo` in an upcoming release). Before a client can attempt to create a new QoD session
+        for the same device and flow period they must release the session resources with an explicit `delete` operation if not yet automatically deleted.
+
       operationId: createSession
       requestBody:
         description: Parameters to create a new session
@@ -110,7 +124,7 @@ paths:
               summary: "Session notifications callback"
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
-                The QoD server will call this endpoint whenever any network related event occurs.
+                The QoD server will call this endpoint whenever any QoS session change (e.g. network termination) related event occurs.
                 Currently only QOS_STATUS_CHANGED event is defined.
               operationId: postNotification
               requestBody:
@@ -206,6 +220,12 @@ paths:
                     status: 400
                     code: OUT_OF_RANGE
                     message: "Invalid port ranges specified: devicePorts"
+                DurationOutOfRangeForQoSProfile:
+                  summary: The requested duration is out of the allowed range for the specific QoS profile
+                  value:
+                    status: 400
+                    code: OUT_OF_RANGE
+                    message: "The requested duration is out of the allowed range for the specific QoS profile"
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
@@ -273,7 +293,13 @@ paths:
       tags:
         - QoS Sessions
       summary: Delete a QoS session
-      description: Free resources related to QoS session
+      description: |
+        Release resources related to QoS session
+
+        If the notification callback is provided and the `qosStatus` of the session was `AVAILABLE` the client will receive in addition to the response a `QOS_STATUS_CHANGED` event with
+        - `qosStatus` as `UNAVAILABLE` and
+        - `statusInfo` as `DELETE_REQUESTED`
+        There will be no notification event if the `qosStatus` was already `UNAVAILABLE`.
       operationId: deleteSession
       parameters:
         - name: sessionId
@@ -308,7 +334,14 @@ paths:
         - QoS Sessions
       summary: "Extend the duration of an active session"
       description: |
-        Extend the duration of an active QoS session. If this operation is executed successfully, the new duration of the target session will be the original duration plus the additional duration. The remaining duration plus the requested additional duration shall not exceed the maximum limit. Otherwise, the new remaining duration will be the maximum limit.
+        Extend the overall duration of an active QoS session. If this operation is executed successfully, the new duration of the target session will be the original duration plus the additionally requested duration.
+        The new remaining duration of the QoS session shall not exceed the maximum remaining duration limit (currently fixed at 86,400 seconds) where the remaining duration is calculated as the difference between the `expiresAt` and current time when the request to extend the session duration is received. If this maximum limit would be exceeded, the overall duration shall be set such that the remaining duration is equal to this limit.
+        An example: A QoD session was originally created with duration 80,000 seconds. 10,000 seconds later, the developer requested to extend the session by 20,000 seconds.
+        - Original duration: 80,000 seconds
+        - Elapsed time: 10,000 seconds
+        - Remaining duration: 70,000 seconds
+        - New remaining duration: 86,400 seconds (the maximum allowed)
+        - New overall session duration: 96,400 seconds
       operationId: extendQosSessionDuration
       parameters:
         - name: sessionId
@@ -473,54 +506,10 @@ components:
       type: string
       format: uuid
 
-    SessionInfo:
-      description: Session related information.
-      allOf:
-        - $ref: "#/components/schemas/CreateSession"
-        - type: object
-          properties:
-            sessionId:
-              $ref: "#/components/schemas/SessionId"
-            startedAt:
-              type: integer
-              example: 1639479600
-              description: Timestamp of session start in seconds since Unix epoch
-              format: int64
-            expiresAt:
-              type: integer
-              example: 1639566000
-              description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
-              format: int64
-            qosStatus:
-              $ref: "#/components/schemas/QosStatus"
-            messages:
-              type: array
-              items:
-                $ref: "#/components/schemas/Message"
-          required:
-            - sessionId
-            - duration
-            - startedAt
-            - expiresAt
-            - qosStatus
-
-    CreateSession:
-      description: Attributes required to create a session
+    BaseSessionInfo:
+      description: Common attributes of a QoD session
       type: object
       properties:
-        duration:
-          description: |
-            Session duration in seconds. Maximal value of 24 hours is used if not set.
-            After session is expired the, client will receive a `QOS_STATUS_CHANGED` event with
-             - `qosStatus` as `UNAVAILABLE`, and,
-             - `statusInfo` as `DURATION_EXPIRED`.
-            See notification callback.
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 86400
-          default: 86400
-          example: 86400
         device:
           $ref: "#/components/schemas/Device"
         applicationServer:
@@ -555,6 +544,62 @@ components:
         - device
         - applicationServer
         - qosProfile
+
+    SessionInfo:
+      description: Session related information.
+      allOf:
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
+            sessionId:
+              $ref: "#/components/schemas/SessionId"
+            duration:
+              type: integer
+              format: int32
+              minimum: 1
+              example: 86400
+            startedAt:
+              type: integer
+              example: 1639479600
+              description: Timestamp of session start in seconds since Unix epoch
+              format: int64
+            expiresAt:
+              type: integer
+              example: 1639566000
+              description: Timestamp of session expiration if the session was not deleted, in seconds since Unix epoch
+              format: int64
+            qosStatus:
+              $ref: "#/components/schemas/QosStatus"
+            messages:
+              type: array
+              items:
+                $ref: "#/components/schemas/Message"
+          required:
+            - sessionId
+            - duration
+            - startedAt
+            - expiresAt
+            - qosStatus
+
+    CreateSession:
+      description: Attributes required to create a session
+      allOf:
+        - $ref: "#/components/schemas/BaseSessionInfo"
+        - type: object
+          properties:
+            duration:
+              description: |
+                Session duration in seconds. Maximal value of 24 hours is used if not set.
+                After session is expired the, client will receive a `QOS_STATUS_CHANGED` event with
+                - `qosStatus` as `UNAVAILABLE`, and,
+                - `statusInfo` as `DURATION_EXPIRED`.
+                See notification callback.
+              type: integer
+              format: int32
+              minimum: 1
+              maximum: 86400
+              default: 86400
+              example: 86400
 
     Port:
       description: TCP or UDP port number
@@ -687,6 +732,8 @@ components:
         maxDuration:
           description: |
             The maximum time period that this profile can be deployed.
+            NOTE: currently the duration within `sessionInfo` is limited to 86400 seconds (1 day).
+            The value of `maxDuration` shouldn't therefore exceed this time period. The limitation might be removed in later versions.
           allOf:
             - $ref: "#/components/schemas/Duration"
         priority:
@@ -887,10 +934,13 @@ components:
         Reason for the new `qosStatus`. Currently `statusInfo` is only applicable when `qosStatus` is 'UNAVAILABLE'.
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
         * `NETWORK_TERMINATED` - Network terminated the session before the requested duration expired
+        * `DELETE_REQUESTED`- User requested the deletion of the session before the requested duration expired
+
       type: string
       enum:
         - DURATION_EXPIRED
         - NETWORK_TERMINATED
+        - DELETE_REQUESTED
 
     Device:
       description: |
@@ -1034,8 +1084,8 @@ components:
     EventQosStatus:
       description: |
         The current status of a requested or previously available session. Applicable values in the event are:
-        *  `AVAILABLE` - The requested QoS has been provided by the network
-        *  `UNAVAILABLE` - A requested or previously available QoS session is currently unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
+        *  `AVAILABLE` - The requested QoS has been provided by the network.
+        *  `UNAVAILABLE` - A requested or previously available QoS session is now unavailable. `statusInfo` may provide additional information about the reason for the unavailability.
       type: string
       enum:
         - AVAILABLE

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,12 +5,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>senf-core</artifactId>
-  <version>v0.10.0-rc</version>
+  <version>v0.10.1</version>
   <packaging>jar</packaging>
   <parent>
     <groupId>com.camara</groupId>
     <artifactId>qod</artifactId>
-    <version>v0.10.0-rc</version>
+    <version>v0.10.1</version>
   </parent>
 
   <dependencies>
@@ -18,13 +18,13 @@
     <dependency>
       <groupId>com.camara</groupId>
       <artifactId>senf-api</artifactId>
-      <version>v0.10.0-rc</version>
+      <version>v0.10.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.camara</groupId>
       <artifactId>3gpp</artifactId>
-      <version>v0.10.0-rc</version>
+      <version>v0.10.1</version>
     </dependency>
 
     <dependency>
@@ -69,30 +69,30 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+      <version>${h2.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-spring</artifactId>
-      <version>2.5.0</version>
+      <version>${cloud-event.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-json-jackson</artifactId>
-      <version>2.5.0</version>
+      <version>${cloud-event.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-http-basic</artifactId>
-      <version>2.5.0</version>
+      <version>${cloud-event.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cloudevents</groupId>
       <artifactId>cloudevents-kafka</artifactId>
-      <version>2.5.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-      <version>2.2.224</version>
+      <version>${cloud-event.version}</version>
     </dependency>
     <dependency>
       <groupId>net.javacrumbs.shedlock</groupId>
@@ -120,18 +120,18 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.1-jre</version>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.seancfoley</groupId>
       <artifactId>ipaddress</artifactId>
-      <version>5.3.4</version>
+      <version>${ipaddress.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -152,12 +152,12 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>4.2.1</version>
+      <version>${java-jwt.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <version>${javax.servlet-api.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/com/camara/qod/config/H2Config.java
+++ b/core/src/main/java/com/camara/qod/config/H2Config.java
@@ -27,6 +27,8 @@ import javax.sql.DataSource;
 import lombok.Getter;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -39,6 +41,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @Getter
 @EnableJpaRepositories("com.camara.qod.repository")
 @Profile("local")
+@EnableAutoConfiguration(exclude = {RedisAutoConfiguration.class})
 public class H2Config {
 
 

--- a/core/src/main/java/com/camara/qod/config/QodConfig.java
+++ b/core/src/main/java/com/camara/qod/config/QodConfig.java
@@ -23,7 +23,10 @@
 
 package com.camara.qod.config;
 
+import java.util.List;
+import java.util.regex.Pattern;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -33,12 +36,18 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @Getter
+@Setter
 @ToString
 public class QodConfig {
 
-  public static final String NETWORK_SEGMENT_REGEX =
-      "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])(?:\\.(?:[01]?\\d\\d?|2[0-4]\\d|25[0-5])){3}(\\/"
-          + "([0-9]|[1-2][0-9]|3[0-2]))$";
+  public static final Pattern IPV4_PATTERN = Pattern.compile(QodConfig.IPV4_REGEX);
+
+  public static final String IPV4_REGEX =
+      "^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)\\.){3}(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(/([0-9]|[1-2][0-9]|3[0-2]))?$";
+
+  public static final String IPV4_WITH_NETWORK_SEGMENT_REGEX =
+      "^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)\\.){3}(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(\\/([0-9]|[1-2][0-9]|3[0-2]))$";
+
   @Value("${qod.qos.references.qos-e}")
   private String qosReferenceQosE;
   @Value("${qod.qos.references.qos-s}")
@@ -61,4 +70,10 @@ public class QodConfig {
   private boolean qosAvailabilityEnabled;
   @Value("${qod.availability.url}")
   private String qosAvailabilityUrl;
+  @Value("${qod.deletion.delay}")
+  private long deletionDelay;
+  @Value("${qod.notifications.ip-filter.allowed-ipv4-addresses}")
+  private List<String> allowedIpv4Addresses;
+  @Value("${qod.notifications.ip-filter.enabled}")
+  private boolean ipFilterEnabled;
 }

--- a/core/src/main/java/com/camara/qod/config/RedisConfig.java
+++ b/core/src/main/java/com/camara/qod/config/RedisConfig.java
@@ -29,6 +29,10 @@ import lombok.Getter;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -42,6 +46,11 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
  */
 @Configuration
 @Getter
+@EnableAutoConfiguration(exclude = {
+    DataSourceAutoConfiguration.class,
+    DataSourceTransactionManagerAutoConfiguration.class,
+    HibernateJpaAutoConfiguration.class
+})
 @EnableRedisRepositories(enableKeyspaceEvents = ON_STARTUP)
 @Profile("!local")
 public class RedisConfig {

--- a/core/src/main/java/com/camara/qod/controller/NotificationsController.java
+++ b/core/src/main/java/com/camara/qod/controller/NotificationsController.java
@@ -23,12 +23,10 @@
 
 package com.camara.qod.controller;
 
-import com.camara.network.api.model.UserPlaneEvent;
 import com.camara.network.api.model.UserPlaneEventReport;
 import com.camara.network.api.model.UserPlaneNotificationData;
 import com.camara.network.api.notifications.NotificationsApi;
 import com.camara.network.api.notifications.NotificationsApiDelegate;
-import com.camara.qod.api.model.QosStatus;
 import com.camara.qod.commons.Util;
 import com.camara.qod.service.NotificationService;
 import jakarta.validation.Valid;
@@ -63,12 +61,7 @@ public class NotificationsController implements NotificationsApiDelegate {
     List<@Valid UserPlaneEventReport> eventReports = userPlaneNotificationData.getEventReports();
 
     for (UserPlaneEventReport report : eventReports) {
-      switch (report.getEvent()) {
-        case SESSION_TERMINATION -> notificationService.handleQosNotification(subscriptionId, UserPlaneEvent.SESSION_TERMINATION);
-        case SUCCESSFUL_RESOURCES_ALLOCATION -> notificationService.setQosStatusForSession(subscriptionId, QosStatus.AVAILABLE);
-        case FAILED_RESOURCES_ALLOCATION -> notificationService.setQosStatusForSession(subscriptionId, QosStatus.UNAVAILABLE);
-        default -> log.warn("Unhandled Notification Event <{}>", report.getEvent());
-      }
+      notificationService.handleQosNotification(subscriptionId, report.getEvent());
     }
     return ResponseEntity.noContent().build();
   }

--- a/core/src/main/java/com/camara/qod/controller/SessionsController.java
+++ b/core/src/main/java/com/camara/qod/controller/SessionsController.java
@@ -27,6 +27,7 @@ import com.camara.qod.api.SessionsApiDelegate;
 import com.camara.qod.api.model.CreateSession;
 import com.camara.qod.api.model.ExtendSessionDuration;
 import com.camara.qod.api.model.SessionInfo;
+import com.camara.qod.api.model.StatusInfo;
 import com.camara.qod.service.SessionService;
 import com.camara.qod.service.ValidationService;
 import java.net.URI;
@@ -46,7 +47,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 public class SessionsController implements SessionsApiDelegate {
 
   private final SessionService sessionService;
-
   private final ValidationService validationService;
 
   /**
@@ -90,7 +90,7 @@ public class SessionsController implements SessionsApiDelegate {
    */
   @Override
   public ResponseEntity<Void> deleteSession(UUID sessionId) {
-    sessionService.deleteSession(sessionId);
+    sessionService.deleteAndNotify(sessionId, StatusInfo.DELETE_REQUESTED);
     return ResponseEntity.noContent().build();
   }
 

--- a/core/src/main/java/com/camara/qod/entity/H2QosSession.java
+++ b/core/src/main/java/com/camara/qod/entity/H2QosSession.java
@@ -33,6 +33,8 @@ import com.camara.qod.util.PortSpecConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
@@ -82,6 +84,7 @@ public class H2QosSession {
   private String notificationAuthToken;
   private long expirationLockUntil; // The lock ensures that the task is only scheduled once for expiration.
   private UUID bookkeeperId;
+  @Enumerated(EnumType.STRING)
   private QosStatus qosStatus;
 
 }

--- a/core/src/main/java/com/camara/qod/exception/ExceptionHandlerAdvice.java
+++ b/core/src/main/java/com/camara/qod/exception/ExceptionHandlerAdvice.java
@@ -212,7 +212,7 @@ public class ExceptionHandlerAdvice {
         errorMessage = "The field '" + invalidField + "' is an unsupported parameter.";
       }
     } else if (throwable instanceof JsonMappingException jsonMappingException) {
-      List<JsonMappingException.Reference> jsonReferences = jsonMappingException.getPath();
+      List<Reference> jsonReferences = jsonMappingException.getPath();
       if (!jsonReferences.isEmpty()) {
         String invalidField = jsonReferences.get(0).getFieldName();
         errorMessage = SCHEMA_VALIDATION_FAILED_MESSAGE + invalidField;
@@ -287,7 +287,7 @@ public class ExceptionHandlerAdvice {
   @SneakyThrows
   @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<Object> handleException(NoResourceFoundException ex) {
-    log.error("No resource found exception occurred: {}", ex.getMessage());
+    log.debug("No resource found exception occurred: {}", ex.getMessage());
     throw ex;
   }
 }

--- a/core/src/main/java/com/camara/qod/kafka/CloudEventProducer.java
+++ b/core/src/main/java/com/camara/qod/kafka/CloudEventProducer.java
@@ -21,8 +21,27 @@
  * ---license-end
  */
 
-package com.camara.qod.exception;
+package com.camara.qod.kafka;
 
-public enum ErrorCode {
-  INVALID_INPUT, VALIDATION_FAILED, PARAMETER_MISSING, NOT_ALLOWED, OUT_OF_RANGE
+import io.cloudevents.CloudEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CloudEventProducer {
+
+  private final KafkaTemplate<String, CloudEvent> kafkaTemplate;
+
+  @Value("${kafka.topic.webhook}")
+  private String qodTopic;
+
+  public void sendEvent(CloudEvent cloudEvent) {
+    log.info("Sending QoD CloudEvent: {} by topic: {}", cloudEvent, qodTopic);
+    kafkaTemplate.send(qodTopic, cloudEvent);
+  }
 }

--- a/core/src/main/java/com/camara/qod/mapping/StorageModelMapper.java
+++ b/core/src/main/java/com/camara/qod/mapping/StorageModelMapper.java
@@ -47,9 +47,11 @@ public interface StorageModelMapper {
   H2QosSession mapToH2QosSession(QosSession qosSession);
 
   @Mapping(source = "id", target = "sessionId")
+  @Mapping(target = "messages", ignore = true)
   QosSession mapToLibraryQosSession(H2QosSession redisQosSession);
 
   @Mapping(source = "id", target = "sessionId")
+  @Mapping(target = "messages", ignore = true)
   QosSession mapToLibraryQosSession(RedisQosSession redisQosSession);
 
   @Mapping(target = "id", expression = "java(java.util.UUID.fromString(redisSet.getValue()))")

--- a/core/src/main/java/com/camara/qod/security/Ipv4AllowListFilter.java
+++ b/core/src/main/java/com/camara/qod/security/Ipv4AllowListFilter.java
@@ -1,0 +1,92 @@
+/*-
+ * ---license-start
+ * CAMARA Project
+ * ---
+ * Copyright (C) 2022 - 2024 Contributors | Deutsche Telekom AG to CAMARA a Series of LF Projects, LLC
+ *
+ * The contributor of this file confirms his sign-off for the Developer Certificate of Origin
+ *             (https://developercertificate.org).
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package com.camara.qod.security;
+
+import com.camara.qod.api.model.ErrorInfo;
+import com.camara.qod.config.QodConfig;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Generated;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@ConditionalOnProperty(prefix = "device-location", name = "notifications.ip-filter.enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class Ipv4AllowListFilter extends OncePerRequestFilter {
+
+  private final Set<String> allowedIpv4Addresses = new HashSet<>();
+
+  private final QodConfig qodConfig;
+
+  @Override
+  @Generated
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return !path.contains("/notifications");
+  }
+
+  @Override
+  protected void initFilterBean() {
+    allowedIpv4Addresses.addAll(qodConfig.getAllowedIpv4Addresses());
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    String ipAddress = request.getRemoteAddr();
+
+    if (allowedIpv4Addresses.contains(ipAddress)) {
+      chain.doFilter(request, response);
+    } else {
+      log.debug("Requested IPv4 {} is not allowed to perform this action.", ipAddress);
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      ErrorInfo errorResponse = new ErrorInfo()
+          .message("Access denied");
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.getWriter().write(convertObjectToJson(errorResponse));
+    }
+  }
+
+  @Generated
+  private String convertObjectToJson(Object object) throws JsonProcessingException {
+    if (object == null) {
+      return null;
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.writeValueAsString(object);
+  }
+}

--- a/core/src/main/java/com/camara/qod/security/SecurityKeycloakConfig.java
+++ b/core/src/main/java/com/camara/qod/security/SecurityKeycloakConfig.java
@@ -49,6 +49,7 @@ public class SecurityKeycloakConfig {
       authorizeRequest.requestMatchers(antMatcher("/actuator/**")).permitAll();
       authorizeRequest.requestMatchers(antMatcher("/qod-api.yaml")).permitAll();
       authorizeRequest.requestMatchers(antMatcher("/h2-console/*")).permitAll();
+      authorizeRequest.requestMatchers(antMatcher("/**/notifications")).permitAll();
       authorizeRequest.anyRequest().authenticated();
     }).csrf(AbstractHttpConfigurer::disable).headers(
         httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));

--- a/core/src/main/java/com/camara/qod/service/QosProfileService.java
+++ b/core/src/main/java/com/camara/qod/service/QosProfileService.java
@@ -33,5 +33,5 @@ public interface QosProfileService {
 
   QosProfile getQosProfile(String name);
 
-
+  
 }

--- a/core/src/main/java/com/camara/qod/service/ValidationService.java
+++ b/core/src/main/java/com/camara/qod/service/ValidationService.java
@@ -23,20 +23,22 @@
 
 package com.camara.qod.service;
 
+import static com.camara.qod.config.QodConfig.IPV4_PATTERN;
+import static com.camara.qod.config.QodConfig.IPV4_WITH_NETWORK_SEGMENT_REGEX;
+
+import com.camara.qod.api.model.BaseSessionInfoWebhook;
 import com.camara.qod.api.model.CreateSession;
-import com.camara.qod.api.model.CreateSessionWebhook;
 import com.camara.qod.api.model.DeviceIpv4Addr;
 import com.camara.qod.config.QodConfig;
 import com.camara.qod.exception.ErrorCode;
 import com.camara.qod.exception.QodApiException;
-import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
 import jakarta.validation.constraints.NotNull;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -59,7 +61,7 @@ public class ValidationService {
     validateAppServerNetwork(createSession.getApplicationServer().getIpv4Address());
     validateDeviceNetwork(createSession.getDevice().getIpv4Address());
 
-    CreateSessionWebhook webhook = createSession.getWebhook();
+    BaseSessionInfoWebhook webhook = createSession.getWebhook();
     if (Objects.nonNull(webhook)) {
       validateNotificationUrl(webhook.getNotificationUrl());
     }
@@ -69,54 +71,53 @@ public class ValidationService {
     try {
       new URL(notificationUrl.toString()).toURI();
     } catch (URISyntaxException | MalformedURLException e) {
-      throw new QodApiException(
-          HttpStatus.BAD_REQUEST,
-          "Validation failed for parameter 'notificationUrl' - Invalid URL-Syntax.",
+      throw new QodApiException(HttpStatus.BAD_REQUEST, "Validation failed for parameter 'notificationUrl' - Invalid URL-Syntax.",
           ErrorCode.VALIDATION_FAILED);
     }
   }
 
   private void validateDuration(Integer duration) {
     if (Objects.isNull(duration)) {
-      throw new QodApiException(HttpStatus.BAD_REQUEST,
-          "Validation failed for parameter 'duration'",
-          ErrorCode.INVALID_INPUT);
+      throw new QodApiException(HttpStatus.BAD_REQUEST, "Validation failed for parameter 'duration'", ErrorCode.INVALID_INPUT);
     }
   }
 
   private void validateDeviceNetwork(DeviceIpv4Addr deviceIpv4) {
     validateExistingParameter(deviceIpv4, "device.ipv4Address");
-    validateExistingParameter(deviceIpv4.getPublicAddress(), "device.ipv4Address.publicAddress");
-    validateIpAddress(deviceIpv4.getPublicAddress(), "device.ipv4Address.publicAddress");
-    validateNetworkSegment(deviceIpv4.getPublicAddress());
-  }
-
-  private void validateNetworkSegment(String deviceIpv4) {
-    // if multiple device.Ipv4Addr are not allowed and specified device.Ipv4Addr is a network segment, return error
-    if (!qodConfig.isQosAllowMultipleDeviceAddr() && deviceIpv4.matches(QodConfig.NETWORK_SEGMENT_REGEX)) {
-      throw new QodApiException(HttpStatus.BAD_REQUEST,
-          "A network segment for Device IPv4 is not allowed in the current configuration: " + deviceIpv4
-              + " is not allowed, but " + deviceIpv4.substring(0, deviceIpv4.indexOf("/"))
-              + " is allowed.", ErrorCode.NOT_ALLOWED);
-    }
+    String publicIpv4FieldName = "device.ipv4Address.publicAddress";
+    validateExistingParameter(deviceIpv4.getPublicAddress(), publicIpv4FieldName);
+    validateIpv4Address(deviceIpv4.getPublicAddress(), publicIpv4FieldName);
   }
 
   private void validateAppServerNetwork(String appServerIpv4) {
     validateExistingParameter(appServerIpv4, "applicationServer.ipv4Address");
-    validateIpAddress(appServerIpv4, "device.ipv4Address.publicAddress");
+    validateIpv4Address(appServerIpv4, "applicationServer.ipv4Address");
   }
 
   /**
-   * Checks if network is defined with the start address, e.g., 2001:db8:85a3:8d3:1319:8a2e:370:7344/128 and not
-   * 2001:db8:85a3:8d3:1319:8a2e:370:7344/120.
+   * Validates an IPv4 address against a specified regular expression pattern.
+   *
+   * @param ipAddress     The IPv4 address to validate.
+   * @param parameterName The name of the parameter associated with the IPv4 address.
+   * @throws QodApiException if the provided IPv4 address is not valid, according to the pattern.
    */
-  private void validateIpAddress(String network, String parameterName) {
-    IPAddress current = new IPAddressString(network).getAddress();
-    IPAddress rewritten = current.toPrefixBlock();
-    if (current != rewritten
-        || network.split("\\.").length != 4) {
-      throw new QodApiException(
-          HttpStatus.BAD_REQUEST, "Network specification for " + parameterName + " not valid " + network, ErrorCode.VALIDATION_FAILED);
+  private void validateIpv4Address(String ipAddress, String parameterName) {
+    if (ipAddress != null) {
+      // if multiple device.Ipv4Addr are not allowed and specified device.Ipv4Addr is a network segment, return error
+      validateNetworkSegment(ipAddress);
+      Matcher matcher = IPV4_PATTERN.matcher(ipAddress);
+      if (!matcher.matches()) {
+        throw new QodApiException(HttpStatus.BAD_REQUEST, "Network specification for " + parameterName + " not valid: <" + ipAddress + ">",
+            ErrorCode.VALIDATION_FAILED);
+      }
+    }
+  }
+
+  private void validateNetworkSegment(String ipAddress) {
+    if (!qodConfig.isQosAllowMultipleDeviceAddr() && ipAddress.matches(IPV4_WITH_NETWORK_SEGMENT_REGEX)) {
+      throw new QodApiException(HttpStatus.BAD_REQUEST,
+          "A network segment for Device IPv4 is not allowed in the current configuration: " + ipAddress + " is not allowed, but "
+              + ipAddress.substring(0, ipAddress.indexOf("/")) + " is allowed.", ErrorCode.NOT_ALLOWED);
     }
   }
 

--- a/core/src/main/resources/application-debug.yml
+++ b/core/src/main/resources/application-debug.yml
@@ -1,12 +1,6 @@
 network:
-  server:
-    apiroot: http://localhost:8081
-    scsasid: scs
   debug: true
 
-qod:
-  availability:
-    url: http://localhost:8091
 spring:
   datasource:
     url: jdbc:h2:mem:qod;DB_CLOSE_DELAY=-1

--- a/core/src/main/resources/application-local.yml
+++ b/core/src/main/resources/application-local.yml
@@ -20,7 +20,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: true
-    database-platform: org.hibernate.dialect.H2Dialect
   sql:
     init:
       mode: always

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -5,7 +5,7 @@ server:
 # T8 reference point, SCEF EP, see http://www.3gpp.org/ftp/Specs/archive/29_series/29.122/
 network:
   server:
-    apiroot: https://example.com
+    apiroot: http://localhost:8081
     scsasid: scs
     flowid:
       qos-e: 3
@@ -43,7 +43,9 @@ qod:
     horizon: false
   cloud-event:
     source:
-      url: http://localhost/sessions
+      url: http://localhost:9091/qod/v0/sessions
+  deletion:
+    delay: 360
   qos:
     references:
       qos-e: qod_1
@@ -54,6 +56,10 @@ qod:
     time-before-handling: 20
     trigger-interval: 10
     lock-time: 2
+  notifications:
+    ip-filter:
+      enabled: ${IP_FILTER_ENABLED:false}
+      allowed-ipv4-addresses: ${ALLOWED_IPV4_ADDRESSES:127.0.0.1}
   mask-sensible-data: true # if set to true, sensible data is masked in response body
   allow-multiple-deviceaddr: true # if set to true, network segments are allowed for ueAddr
   availability:
@@ -74,8 +80,6 @@ management:
     health:
       probes:
         enabled: true
-      show-details: always
-    info:
       enabled: true
 
 spring:

--- a/core/src/main/resources/sql/data.sql
+++ b/core/src/main/resources/sql/data.sql
@@ -1,5 +1,5 @@
-INSERT INTO qos_profiles (name, description, status, max_upstream_rate, max_downstream_rate)
-VALUES ('QOS_E', 'The QOS profile E', 'ACTIVE', '{"value": 1, "unit": "Mbps"}', '{"value": 2, "unit": "Mbps"}'),
-       ('QOS_S', 'The QOS profile S', 'ACTIVE', '{"value": 10, "unit": "Mbps"}', '{"value": 20, "unit": "Mbps"}'),
-       ('QOS_M', 'The QOS profile M', 'ACTIVE', '{"value": 25, "unit": "Mbps"}', '{"value": 50, "unit": "Mbps"}'),
-       ('QOS_L', 'The QOS profile L', 'ACTIVE', '{"value": 50, "unit": "Mbps"}', '{"value": 100, "unit": "Mbps"}');
+INSERT INTO qos_profiles (name, description, status, max_upstream_rate, max_downstream_rate, min_duration, max_duration)
+VALUES ('QOS_E', 'The QOS profile E', 'ACTIVE', '{"value": 1, "unit": "Mbps"}', '{"value": 2, "unit": "Mbps"}', '{"value": 10, "unit": "Seconds"}', '{"value": 30, "unit": "Seconds"}'),
+       ('QOS_S', 'The QOS profile S', 'ACTIVE', '{"value": 10, "unit": "Mbps"}', '{"value": 20, "unit": "Mbps"}', '{"value": 10, "unit": "Seconds"}', '{"value": 5, "unit": "Minutes"}'),
+       ('QOS_M', 'The QOS profile M', 'ACTIVE', '{"value": 25, "unit": "Mbps"}', '{"value": 50, "unit": "Mbps"}', '{"value": 10, "unit": "Seconds"}', '{"value": 5, "unit": "Hours"}'),
+       ('QOS_L', 'The QOS profile L', 'ACTIVE', '{"value": 50, "unit": "Mbps"}', '{"value": 100, "unit": "Mbps"}', '{"value": 10, "unit": "Seconds"}', '{"value": 12, "unit": "Hours"}');

--- a/core/src/test/java/com/camara/qod/annotation/UnsecuredWebMvcTest.java
+++ b/core/src/test/java/com/camara/qod/annotation/UnsecuredWebMvcTest.java
@@ -53,7 +53,7 @@ import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 public @interface UnsecuredWebMvcTest {
 
   /**
-   * Alias for the {@code controllers} attribute of {@link org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest}. Specifies
+   * Alias for the {@code controllers} attribute of {@link WebMvcTest}. Specifies
    * the controller classes to be registered for the test slice.
    *
    * @return the controller classes to be registered for the test slice
@@ -61,7 +61,7 @@ public @interface UnsecuredWebMvcTest {
   @AliasFor(annotation = WebMvcTest.class, attribute = "controllers") Class<?>[] value() default {};
 
   /**
-   * Alias for the {@code controllers} attribute of {@link org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest}. Specifies
+   * Alias for the {@code controllers} attribute of {@link WebMvcTest}. Specifies
    * the controller classes to be registered for the test slice.
    *
    * @return the controller classes to be registered for the test slice

--- a/core/src/test/java/com/camara/qod/controller/NotificationControllerTest.java
+++ b/core/src/test/java/com/camara/qod/controller/NotificationControllerTest.java
@@ -24,26 +24,18 @@
 package com.camara.qod.controller;
 
 import static com.camara.qod.util.NotificationsTestData.NOTIFICATION_URI;
-import static com.camara.qod.util.NotificationsTestData.TEST_NOTIFICATION_REQUEST;
 import static com.camara.qod.util.NotificationsTestData.TEST_NOTIFICATION_REQUEST_EMPTY_TRANSACTION;
 import static com.camara.qod.util.NotificationsTestData.createTestNotificationRequest;
 import static com.camara.qod.util.TestData.getAsJsonFormat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.camara.network.api.model.UserPlaneEvent;
 import com.camara.network.api.notifications.NotificationsApiController;
 import com.camara.qod.annotation.UnsecuredWebMvcTest;
 import com.camara.qod.exception.ExceptionHandlerAdvice;
-import com.camara.qod.exception.QodApiException;
 import com.camara.qod.service.NotificationService;
 import com.camara.qod.service.SessionService;
-import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -51,7 +43,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -75,24 +66,9 @@ class NotificationControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
-  @Test
-  void testNotificationsPost_NoContent_204() throws Exception {
-    when(notificationService.handleQosNotification(anyString(), any())).thenReturn(CompletableFuture.completedFuture(null));
-
-    mockMvc.perform(MockMvcRequestBuilders
-            .post(NOTIFICATION_URI)
-            .accept(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(TEST_NOTIFICATION_REQUEST_EMPTY_TRANSACTION))
-        .andDo(print())
-        .andExpect(status().isNoContent());
-  }
-
   @ParameterizedTest
   @EnumSource(value = UserPlaneEvent.class)
   void testNotificationsPost_AllEvents_NoContent_204(UserPlaneEvent event) throws Exception {
-    when(notificationService.handleQosNotification(anyString(), any())).thenReturn(CompletableFuture.completedFuture(null));
-
     mockMvc.perform(MockMvcRequestBuilders
             .post(NOTIFICATION_URI)
             .accept(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
@@ -104,8 +80,6 @@ class NotificationControllerTest {
 
   @Test
   void testNotificationsPost_NoContent_EmptyTransaction_204() throws Exception {
-    when(notificationService.handleQosNotification(anyString(), any())).thenReturn(CompletableFuture.completedFuture(null));
-
     mockMvc.perform(MockMvcRequestBuilders
             .post(NOTIFICATION_URI)
             .accept(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
@@ -113,39 +87,5 @@ class NotificationControllerTest {
             .content(TEST_NOTIFICATION_REQUEST_EMPTY_TRANSACTION))
         .andDo(print())
         .andExpect(status().isNoContent());
-  }
-
-  @Test
-  void testNotificationsPost_NotFound_404() throws Exception {
-    doThrow(new QodApiException(HttpStatus.NOT_FOUND,
-        "QoD session not found for session ID: 963ab9f5-26e8-48b9-a56e-52ecdeaa9172")).when(
-        notificationService).handleQosNotification(anyString(), any());
-
-    mockMvc.perform(MockMvcRequestBuilders
-            .post(NOTIFICATION_URI)
-            .accept(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(TEST_NOTIFICATION_REQUEST))
-        .andDo(print())
-        .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.message")
-            .value("QoD session not found for session ID: 963ab9f5-26e8-48b9-a56e-52ecdeaa9172"));
-  }
-
-  @Test
-  void testNotificationsPost_ServiceUnavailable_503() throws Exception {
-    doThrow(new QodApiException(HttpStatus.SERVICE_UNAVAILABLE,
-        "The service is currently not available")).when(
-        notificationService).handleQosNotification(anyString(), any());
-
-    mockMvc.perform(MockMvcRequestBuilders
-            .post(NOTIFICATION_URI)
-            .accept(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(TEST_NOTIFICATION_REQUEST))
-        .andDo(print())
-        .andExpect(status().isServiceUnavailable())
-        .andExpect(jsonPath("$.message")
-            .value("The service is currently not available"));
   }
 }

--- a/core/src/test/java/com/camara/qod/security/Ipv4AllowListFilterTest.java
+++ b/core/src/test/java/com/camara/qod/security/Ipv4AllowListFilterTest.java
@@ -1,0 +1,93 @@
+/*-
+ * ---license-start
+ * CAMARA Project
+ * ---
+ * Copyright (C) 2022 - 2024 Contributors | Deutsche Telekom AG to CAMARA a Series of LF Projects, LLC
+ *
+ * The contributor of this file confirms his sign-off for the Developer Certificate of Origin
+ *             (https://developercertificate.org).
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package com.camara.qod.security;
+
+import static com.camara.qod.util.NotificationsTestData.NOTIFICATION_URI;
+import static com.camara.qod.util.NotificationsTestData.TEST_NOTIFICATION_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.camara.qod.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "device-location.notifications.ip-filter.enabled=true"
+})
+@EnableAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, OAuth2ResourceServerAutoConfiguration.class})
+@ActiveProfiles("local")
+@AutoConfigureMockMvc
+class Ipv4AllowListFilterTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private JwtDecoder jwtDecoder;
+  @MockBean
+  private NotificationService notificationService;
+
+  @Test
+  void testNotifications_AllowedIpv4_204() throws Exception {
+    mockMvc.perform(post(NOTIFICATION_URI)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(TEST_NOTIFICATION_REQUEST)
+        )
+        .andDo(print())
+        .andExpect(status().isNoContent());
+    verify(notificationService, times(1)).handleQosNotification(anyString(), any());
+  }
+
+  @Test
+  void testNotifications_ForbiddenIpv4_403() throws Exception {
+
+    mockMvc.perform(post(NOTIFICATION_URI)
+            .with(request -> {
+              request.setRemoteAddr("10.0.0.1");
+              return request;
+            })
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(TEST_NOTIFICATION_REQUEST)
+        )
+        .andDo(print())
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("Access denied"));
+    verify(notificationService, times(0)).handleQosNotification(anyString(), any());
+  }
+}

--- a/core/src/test/java/com/camara/qod/service/EventHubServiceTest.java
+++ b/core/src/test/java/com/camara/qod/service/EventHubServiceTest.java
@@ -1,0 +1,113 @@
+/*-
+ * ---license-start
+ * CAMARA Project
+ * ---
+ * Copyright (C) 2022 - 2024 Contributors | Deutsche Telekom AG to CAMARA a Series of LF Projects, LLC
+ *
+ * The contributor of this file confirms his sign-off for the Developer Certificate of Origin
+ *             (https://developercertificate.org).
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package com.camara.qod.service;
+
+import static com.camara.qod.util.SessionsTestData.createTestSessionInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.camara.qod.api.model.QosStatus;
+import com.camara.qod.api.model.SessionInfo;
+import com.camara.qod.api.model.StatusInfo;
+import com.camara.qod.exception.QodApiException;
+import com.camara.qod.feign.EventHubClient;
+import com.camara.qod.kafka.CloudEventProducer;
+import feign.FeignException;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class EventHubServiceTest {
+
+  @InjectMocks
+  private EventHubService eventHubService;
+
+  @Mock
+  private EventHubClient eventHubClient;
+
+  @Mock
+  private CloudEventProducer cloudEventProducer;
+
+  @SneakyThrows
+  @BeforeEach
+  public void setup() {
+    FieldUtils.writeField(eventHubService,
+        "cloudEventSourceUrl", "http://localhost:9091/qod/v0/sessions", true);
+    FieldUtils.writeField(eventHubService, "isEventhubHorizonConfigured", false, true);
+  }
+
+  @Test
+  void testSendEvent_Kafka_MissingWebhookUrl() {
+    SessionInfo sessionInfo = createTestSessionInfo(UUID.randomUUID());
+    sessionInfo.webhook(null);
+    eventHubService.sendEvent(sessionInfo);
+    verify(cloudEventProducer, times(0)).sendEvent(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(names = {"AVAILABLE", "UNAVAILABLE"})
+  void testSendEvent_Kafka_WithStatusInfo(QosStatus qosStatus) {
+    SessionInfo sessionInfo = createTestSessionInfo();
+    sessionInfo.setQosStatus(qosStatus);
+    eventHubService.sendEvent(sessionInfo, StatusInfo.NETWORK_TERMINATED);
+    verify(cloudEventProducer, times(1)).sendEvent(any());
+  }
+
+  @Test
+  @SneakyThrows
+  void testSendEvent_Horizon_WithStatusInfo() {
+    FieldUtils.writeField(eventHubService, "isEventhubHorizonConfigured", true, true);
+    SessionInfo sessionInfo = createTestSessionInfo();
+    eventHubService.sendEvent(sessionInfo, StatusInfo.NETWORK_TERMINATED);
+    verify(eventHubClient, times(1)).sendEvent(any());
+  }
+
+  @Test
+  @SneakyThrows
+  void testSendEvent_Horizon_FeignException() {
+    doThrow(FeignException.class)
+        .when(eventHubClient).sendEvent(any());
+    FieldUtils.writeField(eventHubService, "isEventhubHorizonConfigured", true, true);
+    SessionInfo sessionInfo = createTestSessionInfo();
+    QodApiException qodApiException = assertThrows(QodApiException.class,
+        () -> eventHubService.sendEvent(sessionInfo, StatusInfo.NETWORK_TERMINATED));
+    assertEquals(HttpStatus.SERVICE_UNAVAILABLE, qodApiException.getHttpStatus());
+    assertEquals("The eventhub service is currently not available", qodApiException.getMessage());
+    verify(eventHubClient, times(1)).sendEvent(any());
+  }
+}

--- a/core/src/test/java/com/camara/qod/service/SessionServiceTest.java
+++ b/core/src/test/java/com/camara/qod/service/SessionServiceTest.java
@@ -1,0 +1,108 @@
+/*-
+ * ---license-start
+ * CAMARA Project
+ * ---
+ * Copyright (C) 2022 - 2024 Contributors | Deutsche Telekom AG to CAMARA a Series of LF Projects, LLC
+ *
+ * The contributor of this file confirms his sign-off for the Developer Certificate of Origin
+ *             (https://developercertificate.org).
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package com.camara.qod.service;
+
+import static com.camara.qod.util.SessionsTestData.getH2QosSessionTestData;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.camara.network.api.AsSessionWithQoSApiSubscriptionLevelDeleteOperationApi;
+import com.camara.qod.api.model.QosStatus;
+import com.camara.qod.api.model.StatusInfo;
+import com.camara.qod.entity.H2QosSession;
+import com.camara.qod.repository.QodSessionH2Repository;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class SessionServiceTest {
+
+  @Autowired
+  private SessionService sessionService;
+
+  @Autowired
+  private QodSessionH2Repository h2Repository;
+
+  @MockBean
+  private EventHubService eventHubService;
+
+  @MockBean
+  private AsSessionWithQoSApiSubscriptionLevelDeleteOperationApi deleteApi;
+
+  private UUID savedSessionId;
+  private String savedSubscriptionId;
+
+  @SneakyThrows
+  @BeforeEach
+  public void setUpTest() {
+    when(eventHubService.sendEvent(any())).thenReturn(CompletableFuture.completedFuture(null));
+    when(eventHubService.sendEvent(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+    H2QosSession savedSession = h2Repository.save(getH2QosSessionTestData());
+    assertEquals(QosStatus.REQUESTED, savedSession.getQosStatus());
+    savedSessionId = savedSession.getId();
+    savedSubscriptionId = savedSession.getSubscriptionId();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    h2Repository.deleteById(savedSessionId);
+  }
+
+  @Test
+  void testDeleteAndNotify() {
+    assertDoesNotThrow(() -> sessionService.deleteAndNotify(savedSessionId, StatusInfo.NETWORK_TERMINATED));
+    verify(eventHubService, times(1)).sendEvent(any(), any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(names = {"AVAILABLE", "UNAVAILABLE"})
+  void testDeleteAndNotify_DeleteRequested(QosStatus qosStatus) {
+    H2QosSession h2QosSession = h2Repository.findBySubscriptionId(savedSubscriptionId).orElse(null);
+    assertNotNull(h2QosSession);
+    h2QosSession.setQosStatus(qosStatus);
+    h2Repository.saveAndFlush(h2QosSession);
+    assertDoesNotThrow(() -> sessionService.deleteAndNotify(savedSessionId, StatusInfo.DELETE_REQUESTED));
+    if (qosStatus == QosStatus.AVAILABLE) {
+      verify(eventHubService, times(1)).sendEvent(any(), any());
+    } else {
+      verify(eventHubService, times(0)).sendEvent(any(), any());
+    }
+  }
+}

--- a/core/src/test/java/com/camara/qod/util/QosProfilesTestData.java
+++ b/core/src/test/java/com/camara/qod/util/QosProfilesTestData.java
@@ -23,9 +23,12 @@
 
 package com.camara.qod.util;
 
+import com.camara.qod.api.model.Duration;
 import com.camara.qod.api.model.QosProfile;
 import com.camara.qod.api.model.QosProfileStatusEnum;
+import com.camara.qod.api.model.TimeUnitEnum;
 import com.camara.qod.entity.QosProfileH2Entity;
+import com.camara.qod.entity.QosProfileRedisEntity;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +37,11 @@ public class QosProfilesTestData extends TestData {
   public static final String QOS_PROFILES_URI = "/qod/v0/qos-profiles";
   public static final String STATUS_PARAMETER = "status";
   public static final String NAME_PARAMETER = "name";
+
+  public static final int PROFILE_MIN_DURATION = 10;
+  public static final Duration minDuration = new Duration().value(PROFILE_MIN_DURATION).unit(TimeUnitEnum.SECONDS);
+  public static final int PROFILE_MAX_DURATION = 86400;
+  public static final Duration maxDuration = new Duration().value(PROFILE_MAX_DURATION).unit(TimeUnitEnum.SECONDS);
 
   /**
    * Generates a list of test {@link QosProfile}.
@@ -46,22 +54,30 @@ public class QosProfilesTestData extends TestData {
     qosProfiles.add(new QosProfile()
         .name("QOS_E")
         .status(QosProfileStatusEnum.ACTIVE)
-        .description("The QOS profile E"));
+        .description("The QOS profile E")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration));
 
     qosProfiles.add(new QosProfile()
         .name("QOS_S")
         .status(QosProfileStatusEnum.ACTIVE)
-        .description("The QOS profile S"));
+        .description("The QOS profile S")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration));
 
     qosProfiles.add(new QosProfile()
         .name("QOS_M")
         .status(QosProfileStatusEnum.ACTIVE)
-        .description("The QOS profile M"));
+        .description("The QOS profile M")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration));
 
     qosProfiles.add(new QosProfile()
         .name("QOS_L")
         .status(QosProfileStatusEnum.ACTIVE)
-        .description("The QOS profile L"));
+        .description("The QOS profile L")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration));
 
     return qosProfiles;
   }
@@ -78,26 +94,90 @@ public class QosProfilesTestData extends TestData {
         .name("QOS_E")
         .status(QosProfileStatusEnum.ACTIVE)
         .description("The QOS profile E")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
         .build());
 
     qosProfiles.add(QosProfileH2Entity.builder()
         .name("QOS_S")
         .status(QosProfileStatusEnum.ACTIVE)
         .description("The QOS profile S")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
         .build());
 
     qosProfiles.add(QosProfileH2Entity.builder()
         .name("QOS_M")
         .status(QosProfileStatusEnum.ACTIVE)
         .description("The QOS profile M")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
         .build());
 
     qosProfiles.add(QosProfileH2Entity.builder()
         .name("QOS_L")
         .status(QosProfileStatusEnum.ACTIVE)
         .description("The QOS profile L")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
         .build());
 
     return qosProfiles;
+  }
+
+  /**
+   * Generates a list of test {@link QosProfileRedisEntity}.
+   *
+   * @return A list containing test QoS profiles entities with predefined properties.
+   */
+  public static List<QosProfileRedisEntity> getQosProfilesRedisEntityTestData() {
+    List<QosProfileRedisEntity> qosProfiles = new ArrayList<>();
+
+    qosProfiles.add(QosProfileRedisEntity.builder()
+        .name("QOS_E")
+        .status(QosProfileStatusEnum.ACTIVE)
+        .description("The QOS profile E")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
+        .build());
+
+    qosProfiles.add(QosProfileRedisEntity.builder()
+        .name("QOS_S")
+        .status(QosProfileStatusEnum.ACTIVE)
+        .description("The QOS profile S")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
+        .build());
+
+    qosProfiles.add(QosProfileRedisEntity.builder()
+        .name("QOS_M")
+        .status(QosProfileStatusEnum.ACTIVE)
+        .description("The QOS profile M")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
+        .build());
+
+    qosProfiles.add(QosProfileRedisEntity.builder()
+        .name("QOS_L")
+        .status(QosProfileStatusEnum.ACTIVE)
+        .description("The QOS profile L")
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
+        .build());
+
+    return qosProfiles;
+  }
+
+  /**
+   * Generates a single object of test {@link QosProfileRedisEntity}.
+   *
+   * @return A single QoS profile entity with predefined properties.
+   */
+  public static QosProfileRedisEntity getSingleQosProfileRedisEntity(String qosProfileName) {
+    return QosProfileRedisEntity.builder()
+        .name(qosProfileName)
+        .maxDuration(maxDuration)
+        .minDuration(minDuration)
+        .build();
   }
 }

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>senf-coverage</artifactId>
-  <version>v0.10.0-rc</version>
+  <version>v0.10.1</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>com.camara</groupId>
     <artifactId>qod</artifactId>
-    <version>v0.10.0-rc</version>
+    <version>v0.10.1</version>
   </parent>
 
   <properties>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.camara</groupId>
       <artifactId>senf-core</artifactId>
-      <version>v0.10.0-rc</version>
+      <version>v0.10.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.camara</groupId>
   <artifactId>qod</artifactId>
-  <version>v0.10.0-rc</version>
+  <version>v0.10.1</version>
   <description>Service Enabling Function for Quality-of-Service</description>
   <organization>
     <name>Deutsche Telekom AG</name>
@@ -23,27 +23,40 @@
     <license.licenseName>apache_v2</license.licenseName>
     <license.projectName>CAMARA Project</license.projectName>
     <license.inceptionYear>2022</license.inceptionYear>
-    <license.git.copyrightLastYear>2023</license.git.copyrightLastYear>
+    <license.git.copyrightLastYear>2024</license.git.copyrightLastYear>
     <!--dependencies-->
-    <code-generator.version>7.2.0</code-generator.version>
-    <datatype-threetenbp-version>2.12.2</datatype-threetenbp-version>
+    <code-generator.version>7.4.0</code-generator.version>
+    <datatype-threetenbp-version>2.15.2</datatype-threetenbp-version>
     <jackson-databind-nullable>0.2.6</jackson-databind-nullable>
-    <jodatime-version>2.12.2</jodatime-version>
-    <lombok.version>1.18.30</lombok.version>
+    <jodatime-version>2.12.7</jodatime-version>
+    <lombok.version>1.18.32</lombok.version>
     <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
-    <maven-plugin.version>3.2.2</maven-plugin.version>
+    <maven-plugin.version>3.2.5</maven-plugin.version>
     <migbase64-version>2.2</migbase64-version>
-    <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+    <org.mapstruct.version>1.6.0.Beta1</org.mapstruct.version>
     <plugin.checkstyle.version>3.3.1</plugin.checkstyle.version>
-    <plugin.jacoco.version>0.8.11</plugin.jacoco.version>
-    <shedlock-spring.version>5.2.0</shedlock-spring.version>
-    <spotbugs.version>4.8.2.0</spotbugs.version>
-    <spring.boot.version>3.2.1</spring.boot.version>
-    <spring.cloud.version>2023.0.0</spring.cloud.version>
-    <springdoc.version>2.3.0</springdoc.version>
+    <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
+    <shedlock-spring.version>5.13.0</shedlock-spring.version>
+    <spotbugs.version>4.8.4.0</spotbugs.version>
+    <spring.boot.version>3.2.5</spring.boot.version>
+    <spring.cloud.version>2023.0.1</spring.cloud.version>
+    <springdoc.version>2.5.0</springdoc.version>
+    <jakarta-version>3.1.0-M2</jakarta-version>
     <springfox-version>3.0.0</springfox-version>
-    <swagger-annotations-version>2.2.8</swagger-annotations-version>
-    <threetenbp-version>1.6.5</threetenbp-version>
+    <swagger-annotations-version>2.2.21</swagger-annotations-version>
+    <threetenbp-version>1.6.9</threetenbp-version>
+    <checkstyle.version>10.15.0</checkstyle.version>
+    <java-jwt.version>4.4.0</java-jwt.version>
+    <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <gitlab-code-quality-plugin.version>1.1.0</gitlab-code-quality-plugin.version>
+    <guava.version>33.1.0-jre</guava.version>
+    <awaitility.version>4.2.1</awaitility.version>
+    <ipaddress.version>5.5.0</ipaddress.version>
+    <servlet-api.version>2.5</servlet-api.version>
+    <h2.version>2.2.224</h2.version>
+    <cloud-event.version>3.0.0</cloud-event.version>
+    <license-maven-plugin.version>2.4.0</license-maven-plugin.version>
   </properties>
 
   <modules>
@@ -83,7 +96,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>${license-maven-plugin.version}</version>
         <configuration>
           <outputDirectory>.</outputDirectory>
           <thirdPartyFilename>THIRD-PARTY.md</thirdPartyFilename>
@@ -108,7 +121,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <compilerArgs>
             <arg>-parameters</arg>
@@ -155,7 +168,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.2</version>
+            <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -171,7 +184,7 @@
       <plugin>
         <groupId>de.chkal.maven</groupId>
         <artifactId>gitlab-code-quality-plugin</artifactId>
-        <version>1.0.2</version>
+        <version>${gitlab-code-quality-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature

#### What this PR does / why we need it:

Implementation for v0.10.1


#### Changelog input

```
### v0.10.1

- adaption for extending a session
- check creation of session based on requested QoS profile
- dependency upgrades

### v0.10.0

- Align event notification with CloudEvents spec
- Added a new operation /sessions/{sessionId}/extend which allows extending the duration of an active session
- Added "DELETE_REQUESTED" as statusInfo information via CloudEvent, when a session got deleted by the user
- If the network calls back with SESSION_TERMINATION or FAILED_RESOURCES_ALLOCATION, then after 360s the session will be deleted.
- Single IP addresses in Device-model specified with standard formats instead of patterns
- Add IPv4 validation for device.ipv4Address.publicAddress
- Improve security for REST-Endpoints
- Notification event structure updated to comply with CloudEvents specification.
- In the Device model, single IP addresses are now specified with standard formats instead of patterns.
- Notifications will now be sent for all changes of QosStatus, even if initiated by the client.
- remove automatic attachment of "/notifications" from notificationUrl for CloudEvents

```