### PR TITLE
Updated embedded redis dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,9 +112,9 @@
       <version>${shedlock-spring.version}</version>
     </dependency>
     <dependency>
-      <groupId>it.ozimov</groupId>
-      <artifactId>embedded-redis</artifactId> <!-- Embedded Redis for Unit Tests-->
-      <version>0.7.3</version>
+      <groupId>com.github.codemonstur</groupId>
+      <artifactId>embedded-redis</artifactId>
+      <version>1.4.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/test/java/com/camara/qod/controller/SessionsControllerIntegrationTest.java
+++ b/core/src/test/java/com/camara/qod/controller/SessionsControllerIntegrationTest.java
@@ -79,6 +79,7 @@ import com.camara.qod.service.ExpiredSessionMonitor;
 import com.camara.qod.service.StorageService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import feign.FeignException;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -150,7 +151,7 @@ class SessionsControllerIntegrationTest {
   static final int MAX_VALUE_SECONDS_PER_DAY = 86399;
 
   @BeforeAll
-  public static void setUp() {
+  public static void setUp() throws IOException {
     redisServer = new RedisServer(6370); // RedisServer.builder().port(6370).setting("maxheap 128M").build();
     if (redisServer.isActive()) {
       redisServer.stop();
@@ -159,7 +160,7 @@ class SessionsControllerIntegrationTest {
   }
 
   @AfterAll
-  public static void tearDown() {
+  public static void tearDown() throws IOException {
     redisServer.stop();
   }
 

--- a/core/src/test/java/com/camara/qod/service/RedisQosProfileServiceTest.java
+++ b/core/src/test/java/com/camara/qod/service/RedisQosProfileServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.camara.qod.api.model.QosProfile;
 import com.camara.qod.api.model.QosProfileStatusEnum;
 import com.camara.qod.exception.QodApiException;
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,7 +54,7 @@ class RedisQosProfileServiceTest {
   private static RedisServer redisServer = null;
 
   @BeforeAll
-  public static void setUp() {
+  public static void setUp() throws IOException {
     redisServer = new RedisServer(6370);
     if (redisServer.isActive()) {
       redisServer.stop();
@@ -62,7 +63,7 @@ class RedisQosProfileServiceTest {
   }
 
   @AfterAll
-  public static void tearDown() {
+  public static void tearDown() throws IOException {
     redisServer.stop();
   }
 


### PR DESCRIPTION

#### What type of PR is this?

* tests

#### What this PR does / why we need it:

it.ozimov.embedded-redis:0.7.3 seems outdated and the embedded redis server is not working. Replaced it with com.github.codemonstur.embedded-redis:1.4.3 which is a fork of it.ozimov.embedded-redis and is actively being maintained


#### Which issue(s) this PR fixes:

Fixes #17
