### PR TITLE
Protecting CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,6 @@
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
 * @hdamker @shilpa-padgaonkar @maxl2287
+
+# Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
+/CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Setting @camaraproject/admins as codeowner of the CODEOWNERS file.
See https://github.com/camaraproject/Governance/issues/134 for context.

